### PR TITLE
Web: Add 'development' docker target

### DIFF
--- a/src/docker-compose.dev.yml
+++ b/src/docker-compose.dev.yml
@@ -27,7 +27,20 @@ services:
       - capture-serv_node_modules:/usr/src/app/node_modules     
     command: ["npx", "nodemon", "--inspect=0.0.0.0:9229", "app.js"]
 
+  web:
+    build:
+      target: development
+      args:
+        - DOT_ENV=.env.development
+    environment:
+      NODE_ENV: development
+    volumes:
+      - ./web:/usr/src/app
+      - web_node_modules:/usr/src/app/node_modules
+    command: ["npm", "start"]
+
 volumes:
   capture-serv_node_modules:
   page-serv_node_modules:
+  web_node_modules:
 

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -35,4 +35,4 @@ services:
       - page-serv
       - capture-serv 
     ports:
-      - 5000:5000
+      - 5000:3000

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -1,16 +1,19 @@
-FROM node:14.16-alpine AS build
+FROM node:14.16-alpine AS development
 WORKDIR /usr/src/app
 COPY ["package.json", "package-lock.json", "./"]
 RUN npm install --silent
-COPY ["src", "src/"]
-COPY ["public", "public/"]
 ARG DOT_ENV=".env.production"
 COPY ${DOT_ENV} ./.env
+
+
+FROM development as build
+COPY ["src", "src/"]
+COPY ["public", "public/"]
 RUN npm run build
 
-FROM node:15.14-alpine AS production
+FROM node:14.16-alpine AS production
 WORKDIR /usr/src/app
 RUN npm install -g serve
-EXPOSE 5000
+EXPOSE 3000
 COPY --from=build "/usr/src/app/build/" "./build/"
 CMD ["serve", "build"]


### PR DESCRIPTION
Similar to how backend services work. Maps container's app dir to local file system