### PR TITLE
Make Express services shut down more gracefully

### DIFF
--- a/.github/workflows/capture-serv-test.yml
+++ b/.github/workflows/capture-serv-test.yml
@@ -18,13 +18,13 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Build
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml build capture-serv
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml build capture-serv
     
     - name: Lint
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run capture-serv npx eslint
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run capture-serv npx eslint
       
     - name: Check code style
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run capture-serv npx prettier --check .
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run capture-serv npx prettier --check .
       
     - name: Run tests
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run capture-serv npm test
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run capture-serv npm test

--- a/.github/workflows/page-serv-test.yml
+++ b/.github/workflows/page-serv-test.yml
@@ -18,13 +18,13 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Build
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml build page-serv
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml build page-serv
     
     - name: Lint
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run page-serv npx eslint
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run page-serv npx eslint
       
     - name: Check code style
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run page-serv npx prettier --check .
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run page-serv npx prettier --check .
       
     - name: Run tests
-      run: docker-compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run page-serv npm test
+      run: docker compose -f ./src/docker-compose.yml -f ./src/docker-compose.dev.yml run page-serv npm test

--- a/src/capture-serv/app.js
+++ b/src/capture-serv/app.js
@@ -45,8 +45,8 @@ const server = app.listen(port, () => {
 });
 
 // Make the process exit faster on polite kill signals (Ctrl-C, docker container stop):
-process.once('SIGTERM', () => {
-  server.close()
-})
+process.once("SIGTERM", () => {
+  server.close();
+});
 
 module.exports = { app, server };

--- a/src/capture-serv/app.js
+++ b/src/capture-serv/app.js
@@ -44,4 +44,9 @@ const server = app.listen(port, () => {
   console.log(`Express started on port ${port}`);
 });
 
+// Make the process exit faster on polite kill signals (Ctrl-C, docker container stop):
+process.once('SIGTERM', () => {
+  server.close()
+})
+
 module.exports = { app, server };

--- a/src/page-serv/app.js
+++ b/src/page-serv/app.js
@@ -116,4 +116,9 @@ const server = app.listen(port, () => {
   console.log(`Page service started on port ${port}`);
 });
 
+// Make the process exit faster on polite kill signals (Ctrl-C, docker container stop):
+process.once('SIGTERM', () => {
+  server.close()
+})
+
 module.exports = { app, server };

--- a/src/page-serv/app.js
+++ b/src/page-serv/app.js
@@ -117,8 +117,8 @@ const server = app.listen(port, () => {
 });
 
 // Make the process exit faster on polite kill signals (Ctrl-C, docker container stop):
-process.once('SIGTERM', () => {
-  server.close()
-})
+process.once("SIGTERM", () => {
+  server.close();
+});
 
 module.exports = { app, server };


### PR DESCRIPTION
Adds a SIGTERM handler to close the HTTP server to both Express services.
```js
// Make the process exit faster on polite kill signals (Ctrl-C, docker container stop):
process.once('SIGTERM', () => {
  server.close()
})
```


Before:
```
[+] Running 4/4
 ✔ hs/hs-page-serv:latest        Built                                                                                                                                                         0.0s 
 ✔ hs/hs-capture-serv:latest     Built                                                                                                                                                         0.0s 
 ✔ Container src-capture-serv-1  Recreated                                                                                                                                                     0.1s 
 ✔ Container src-page-serv-1     Recreated                                                                                                                                                     0.1s 
Attaching to capture-serv-1, page-serv-1
capture-serv-1  | Express started on port 3000
page-serv-1     | Page service started on port 3000
page-serv-1     | Connected to database at  ./page-serv.db
Gracefully Stopping... press Ctrl+C again to force
 Container src-capture-serv-1  Stopping
 Container src-page-serv-1  Stopping
 Container src-page-serv-1  Stopped
page-serv-1 exited with code 137
 Container src-capture-serv-1  Stopped
```

After:
```
[+] Running 4/4
 ✔ hs/hs-capture-serv:latest     Built                                                                                                                                                         0.0s 
 ✔ hs/hs-page-serv:latest        Built                                                                                                                                                         0.0s 
 ✔ Container src-page-serv-1     Recreated                                                                                                                                                     0.1s 
 ✔ Container src-capture-serv-1  Recreated                                                                                                                                                     0.1s 
Attaching to capture-serv-1, page-serv-1
capture-serv-1  | Express started on port 3000
page-serv-1     | Page service started on port 3000
page-serv-1     | Connected to database at  ./page-serv.db
Gracefully Stopping... press Ctrl+C again to force
 Container src-capture-serv-1  Stopping
 Container src-page-serv-1  Stopping
 Container src-page-serv-1  Stopped
page-serv-1 exited with code 0
 Container src-capture-serv-1  Stopped
```

Shutdown now goes quite a bit quicker and doesn’t produce that weird exit code 137.